### PR TITLE
confirmation messages in memory, reaction on confirmation, delete with X

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,18 +7,27 @@ const client = new Discord.Client();
 client.once('ready', () => console.log('Ready!'));
 
 let channelsMap;
+const confirmedMessages = [];
 
 if (mode === "dev") {
-  client.on('message', message => message.react(confirmationEmoji));
   channelsMap = {};
   channelsMap['780159998151098378'] = '765940655939125299';
   channelsMap['784885854744084510'] = '784852416591953951';
+  client.on('message', message => { 
+    if (listeningToChannel(message.channel.id)) {
+      message.react(confirmationEmoji); 
+    }
+  });
+
 } else {
   channelsMap = channels;
 }
 
 client.on('messageReactionAdd', async (reaction) => {
   if (listeningToChannel(reaction.message.channel.id)) {
+    if (reaction.emoji.name === '❌') {
+      shouldDeleteMessage(reaction);
+    }
     const shouldConfirm = await shouldConfirmMessage(reaction);
     if (shouldConfirm) {
       handleMessage(reaction.message);
@@ -27,6 +36,32 @@ client.on('messageReactionAdd', async (reaction) => {
 });
 
 client.login(token);
+
+function shouldDeleteMessage(reaction) {
+  const confirmedMessage = confirmedMessages.find(c => c.message === reaction.message.id);
+  if (!confirmedMessage) {
+    return false
+  }
+
+  const shouldDelete = reaction.users.cache.some(u => {
+    const member = reaction.message.guild.member(u.id);
+    return u.id == reaction.message.author || isTrustedConfirmer(member);
+  });
+
+  if (shouldDelete) {
+    confirmedMessage.confirmations.forEach(async m => {
+      const channel = await reaction.message.guild.channels.cache.get(m.channel);
+      const message = await channel.messages.fetch(m.message);
+      message.edit(`~~${message.content}~~ \nThis buff has been cancelled.`);
+    })
+    reaction.message.reactions.cache.get('🆗').remove();
+  }
+}
+
+function isTrustedConfirmer(member) {
+  const userRoles = member.roles.cache.map(r => r.name);
+  return userRoles.some(role => trustedConfirmerRoles.includes(role));
+}
 
 function listeningToChannel(channelId) {
   return channelsMap.hasOwnProperty(channelId);
@@ -42,7 +77,8 @@ async function shouldConfirmMessage(reaction) {
   const dbMessages = await db('buff_messages').where({
     message_id: reaction.message.id
   })
-  if (dbMessages.length > 0) {
+
+  if (dbMessages.length > 0 || confirmedMessages.some(c => c.message === reaction.message.id)) {
     return false;
   }
 
@@ -68,10 +104,6 @@ async function shouldConfirmMessage(reaction) {
 
 async function handleMessage(reactionMessage) {
   try {
-    await db('buff_messages').insert({
-      message_id: reactionMessage.id
-    });
-
     const buff = reactionMessage.content.match(regexes.buff);
     const time = reactionMessage.content.match(regexes.time);
 
@@ -79,13 +111,26 @@ async function handleMessage(reactionMessage) {
       return reactionMessage.reply('Your buff has not been confirmed because it was not properly formatted. It must contain a buff name and a timestamp. Please post a new message.');
     }
 
+    confirmedMessages.push({
+      message: reactionMessage.id,
+      author: reactionMessage.author.id,
+      confirmations: []
+    });
+    await db('buff_messages').insert({
+      message_id: reactionMessage.id
+    });
+    const confirmationMessage = confirmedMessages.find(c => c.message === reactionMessage.id);
+
     const messageContent = formatMessage(buff[0], reactionMessage);
 
     if (['hakkar', 'hoh', 'heart'].includes(buff[0].toLowerCase())) {
       Object.values(channelsMap).forEach(async channel => {
         const outputChannel = reactionMessage.channel.guild.channels.cache.get(channel);
         const message = await outputChannel.send(messageContent);
-
+        confirmationMessage.confirmations.push({
+          channel: message.channel.id,
+          message: message.id
+        });
         if (message.channel.type === 'news') {
           await message.crosspost();
         }
@@ -93,11 +138,16 @@ async function handleMessage(reactionMessage) {
     } else {
       const outputChannel = reactionMessage.channel.guild.channels.cache.get(channelsMap[reactionMessage.channel.id]);
       const message = await outputChannel.send(messageContent);
-
+      confirmationMessage.confirmations.push({
+        channel: message.channel.id,
+        message: message.id
+      });
       if (message.channel.type === 'news') {
         await message.crosspost();
       }
     }
+
+    reactionMessage.react('🆗');
   } catch (err) {
     console.log(err);
   }


### PR DESCRIPTION
- Reacts with OK emote on confirmations
- added `confirmedMessages` global array which stores messages already confirmed. This is used for checking (in addition to DB check) if message was already confirmed + stores confirmation messages the bot posts so they can be edited later
- Message author + trusted users can react with X to cancel the confirmation. Either on the original message or the confirmation message. This will strikeout the message and append "This buff has been cancelled".
- Small edit to dev mode so it only reacts to messages in test channels.